### PR TITLE
Added new info to register

### DIFF
--- a/src_code/BoundlessBrilliance/Controller/RegisterController.swift
+++ b/src_code/BoundlessBrilliance/Controller/RegisterController.swift
@@ -102,7 +102,7 @@ class RegisterController: UIViewController {
     // registerButton action -- Send data to Firebase
     @objc func handleRegister() {
         // Ensure email and password are valid values
-        guard let name = nameTextField.text, let email = emailTextField.text, let password = passwordTextField.text, let chapter = chapterTextField.text
+        guard let name = nameTextField.text, let email = emailTextField.text, let password = passwordTextField.text, let chapter = chapterTextField.text, let memberType = memberTypeTextField.text
             else {
                 print("Form input is not valid")
                 return
@@ -133,7 +133,8 @@ class RegisterController: UIViewController {
                 let userFields = ["name" : name,
                                   "email" : email,
                                   "password" : password,
-                                  "chapter" : chapter]
+                                  "chapter" : chapter,
+                                  "memberType" : memberType]
 
                 // updateChildValues with completion block
                 userRef.updateChildValues(userFields) {

--- a/src_code/BoundlessBrilliance/Controller/RegisterController.swift
+++ b/src_code/BoundlessBrilliance/Controller/RegisterController.swift
@@ -13,7 +13,7 @@ import Toast_Swift
 class RegisterController: UIViewController {
     
     // Spinner options for chapterTextField
-    let chapters = ["", "Azusa Pacific University", "L.A. Trade Tech College", "Occidental College"]
+    let chapters = ["", "Azusa Pacific University", "Los Angeles Trade Tech College", "Occidental College"]
     let memberTypes = ["", "Presenter", "Outreach Coordinator", "Management"]
     
     // subview - nameTextField
@@ -120,31 +120,49 @@ class RegisterController: UIViewController {
                     self.view.makeToast("Error in creating account")
                     return
                 } else {
+                    // Successful Authentication, now save user
+                    /*Store user info, temporarily set fire db rules to true, by default both set to fault*/
+                    var ref: DatabaseReference!
+                    
+                    //save user to users table
+                    ref = Database.database().reference(fromURL: "https://boundless-brilliance-22fa0.firebaseio.com/")
+                    let userID = Auth.auth().currentUser!.uid
+                    
+                    let userRef = ref.child("users").child(userID)
+                    let userFields = ["name" : name,
+                                      "email" : email,
+                                      "chapter" : chapter,
+                                      "memberType" : memberType]
+                    
+                    // updateChildValues with completion block
+                    userRef.updateChildValues(userFields) {
+                        (error:Error?, ref:DatabaseReference) in
+                        if let error = error {
+                            print("Data could not be saved: \(error).")
+                        } else {
+                            print("Data saved successfully!")
+                        }
+                    }
+                    
+                    
+                    //Now save the user under the appropriate chapter table
+                    let chapterRef = ref.child("chapters").child(chapter)
+                    let member = [userID : name]
+
+                    chapterRef.updateChildValues(member) {
+                        (error:Error?, ref:DatabaseReference) in
+                        if let error = error {
+                            print("Data could not be saved: \(error).")
+                        } else {
+                            print("Data saved successfully!")
+                        }
+                    }
+
+                    //after saving all the data successfully, navigate back to login screen
                     let newViewController = LoginScreenController()
                     self.present(newViewController, animated: true)
                 }
-                // Successful Authentication, now save user
-                /*Store user info, temporarily set fire db rules to true, by default both set to fault*/
-                var ref: DatabaseReference!
-
-                ref = Database.database().reference(fromURL: "https://boundless-brilliance-22fa0.firebaseio.com/")
-                let userID = Auth.auth().currentUser!.uid
-                let userRef = ref.child("users").child(userID)
-                let userFields = ["name" : name,
-                                  "email" : email,
-                                  "password" : password,
-                                  "chapter" : chapter,
-                                  "memberType" : memberType]
-
-                // updateChildValues with completion block
-                userRef.updateChildValues(userFields) {
-                    (error:Error?, ref:DatabaseReference) in
-                    if let error = error {
-                        print("Data could not be saved: \(error).")
-                    } else {
-                        print("Data saved successfully!")
-                    }
-                }                                                                      
+               
             })
         }
     }
@@ -152,6 +170,8 @@ class RegisterController: UIViewController {
 // MAIN DISPLAY -------------------------------------------------------------------------------------------------------------------------
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        //updateChapterOptions()
         
     //NAMING VARIABLES ----------
         
@@ -301,6 +321,28 @@ class RegisterController: UIViewController {
         returnButton.widthAnchor.constraint(equalTo: inputsView.widthAnchor).isActive = true
         returnButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
     }
+    
+//    func updateChapterOptions() {
+//        var ref: DatabaseReference!
+//
+//        ref = Database.database().reference(fromURL: "https://boundless-brilliance-22fa0.firebaseio.com/")
+//
+//        ref.observeSingleEvent(of: .value, with: { (snapshot) in
+//
+//            //if the chapters table exists, pull the data from from the chapters table and load it into the ChapterSpinner Array
+//            if snapshot.hasChild("chapters"){
+//                print("chapters exist")
+//            }
+//            //if the chapters table doesn't exist, create it, add the chapters manually into the db, then populate the array from the db
+//            else{
+//                ref.child("chapters").child("Azusa Pacific University")
+//                print("chapters doesn't exist")
+//            }
+//
+//
+//        })
+//
+//    }
 
 // Make originally black status bar white
     override var preferredStatusBarStyle: UIStatusBarStyle { get { return .lightContent } }

--- a/src_code/BoundlessBrilliance/Controller/RegisterController.swift
+++ b/src_code/BoundlessBrilliance/Controller/RegisterController.swift
@@ -13,6 +13,7 @@ import Toast_Swift
 class RegisterController: UIViewController {
     
     // Spinner options for chapterTextField
+    //TODO: in the future, we should pull chapter names from the database in case there are new chapters
     let chapters = ["", "Azusa Pacific University", "Los Angeles Trade Tech College", "Occidental College"]
     let memberTypes = ["", "Presenter", "Outreach Coordinator", "Management"]
     
@@ -112,6 +113,12 @@ class RegisterController: UIViewController {
             //print("Password must be at least 7 characters.")
             self.view.makeToast("Password must be at least 7 characters.")
             return
+        } else if chapter == "" {
+            self.view.makeToast("Please choose a chapter.")
+            return
+        } else if memberType == "" {
+            self.view.makeToast("Please choose a member type.")
+            return
         } else {
             // Register User
             Auth.auth().createUser(withEmail: email, password: password, completion: { (user, error) in
@@ -170,8 +177,6 @@ class RegisterController: UIViewController {
 // MAIN DISPLAY -------------------------------------------------------------------------------------------------------------------------
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        //updateChapterOptions()
         
     //NAMING VARIABLES ----------
         
@@ -322,27 +327,6 @@ class RegisterController: UIViewController {
         returnButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
     }
     
-//    func updateChapterOptions() {
-//        var ref: DatabaseReference!
-//
-//        ref = Database.database().reference(fromURL: "https://boundless-brilliance-22fa0.firebaseio.com/")
-//
-//        ref.observeSingleEvent(of: .value, with: { (snapshot) in
-//
-//            //if the chapters table exists, pull the data from from the chapters table and load it into the ChapterSpinner Array
-//            if snapshot.hasChild("chapters"){
-//                print("chapters exist")
-//            }
-//            //if the chapters table doesn't exist, create it, add the chapters manually into the db, then populate the array from the db
-//            else{
-//                ref.child("chapters").child("Azusa Pacific University")
-//                print("chapters doesn't exist")
-//            }
-//
-//
-//        })
-//
-//    }
 
 // Make originally black status bar white
     override var preferredStatusBarStyle: UIStatusBarStyle { get { return .lightContent } }

--- a/src_code/BoundlessBrilliance/Controller/RegisterController.swift
+++ b/src_code/BoundlessBrilliance/Controller/RegisterController.swift
@@ -14,6 +14,7 @@ class RegisterController: UIViewController {
     
     // Spinner options for chapterTextField
     let chapters = ["", "Azusa Pacific University", "L.A. Trade Tech College", "Occidental College"]
+    let memberTypes = ["", "Presenter", "Outreach Coordinator", "Management"]
     
     // subview - nameTextField
     let nameTextField: UITextField = {
@@ -46,6 +47,14 @@ class RegisterController: UIViewController {
     let chapterTextField: UITextField! = {
         let tf = UITextField()
         tf.placeholder = "Chapter"
+        tf.translatesAutoresizingMaskIntoConstraints = false
+        return tf
+    }()
+    
+    // subview - chapterTextField
+    let memberTypeTextField: UITextField! = {
+        let tf = UITextField()
+        tf.placeholder = "Member Type"
         tf.translatesAutoresizingMaskIntoConstraints = false
         return tf
     }()
@@ -90,7 +99,7 @@ class RegisterController: UIViewController {
         self.present(returnToLoginController, animated: true)
     }
     
-    // registerButton action
+    // registerButton action -- Send data to Firebase
     @objc func handleRegister() {
         // Ensure email and password are valid values
         guard let name = nameTextField.text, let email = emailTextField.text, let password = passwordTextField.text, let chapter = chapterTextField.text
@@ -159,8 +168,9 @@ class RegisterController: UIViewController {
         let nameSeparatorView = registerView.nameSeparatorView
         let emailSeparatorView = registerView.emailSeparatorView
         let passwordSeparatorView = registerView.passwordSeparatorView
-        chapterTextField?.loadSpinnerOptions(spinnerOptions: chapters)
-
+        let chapterSeparatorView = registerView.chapterSeparatorView
+        chapterTextField?.loadChapterOptions(spinnerOptions: chapters)
+        memberTypeTextField?.loadMemberTypeOptions(spinnerOptions: memberTypes)
         
         view.backgroundColor = UIColor(r: 255, g: 255, b: 255);
         
@@ -180,8 +190,10 @@ class RegisterController: UIViewController {
         inputsView.addSubview(emailSeparatorView)
         inputsView.addSubview(passwordTextField)
         inputsView.addSubview(passwordSeparatorView)
-
+        
         inputsView.addSubview(chapterTextField!)
+        inputsView.addSubview(chapterSeparatorView)
+        inputsView.addSubview(memberTypeTextField!)
         
     //FORMAT VIEWS-----------------
         
@@ -189,7 +201,8 @@ class RegisterController: UIViewController {
         setupProfileImageView(profileImageView: profileImageView, inputsView: inputsView)
         setUpInputsView(inputsView: inputsView, nameSeparatorView: nameSeparatorView,
                                 emailSeparatorView: emailSeparatorView,
-                                passwordSeparatorView: passwordSeparatorView)
+                                passwordSeparatorView: passwordSeparatorView,
+                                chapterSeparatorView: chapterSeparatorView)
         setupRegisterButton(inputsView: inputsView)
         setupReturnButton(inputsView: inputsView)
         
@@ -208,20 +221,20 @@ class RegisterController: UIViewController {
     }
     
 
-    func setUpInputsView(inputsView: UIView, nameSeparatorView: UIView, emailSeparatorView: UIView, passwordSeparatorView: UIView) {
+    func setUpInputsView(inputsView: UIView, nameSeparatorView: UIView, emailSeparatorView: UIView, passwordSeparatorView: UIView, chapterSeparatorView: UIView) {
         
         /* inputsView: need x, y, width, height contraints */
         inputsView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         inputsView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         inputsView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1, constant: -24).isActive = true
-        inputsView.heightAnchor.constraint(equalToConstant: 150).isActive = true
+        inputsView.heightAnchor.constraint(equalToConstant: 200).isActive = true
         
         
         // nameTextField: need x, y, width, height contraints
         nameTextField.leftAnchor.constraint(equalTo: inputsView.leftAnchor, constant: 12).isActive = true
         nameTextField.topAnchor.constraint(equalTo: inputsView.topAnchor).isActive = true
         nameTextField.widthAnchor.constraint(equalTo: inputsView.widthAnchor).isActive = true
-        nameTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/4).isActive = true // 1/4 of entire height
+        nameTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/5).isActive = true // 1/4 of entire height
         
         // nameSeparatorView: need x, y, width, height contraints
         nameSeparatorView.leftAnchor.constraint(equalTo: inputsView.leftAnchor).isActive = true
@@ -233,7 +246,7 @@ class RegisterController: UIViewController {
         emailTextField.leftAnchor.constraint(equalTo: inputsView.leftAnchor, constant: 12).isActive = true
         emailTextField.topAnchor.constraint(equalTo: nameTextField.bottomAnchor).isActive = true
         emailTextField.widthAnchor.constraint(equalTo: inputsView.widthAnchor).isActive = true
-        emailTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/4).isActive = true // 1/4 of entire height
+        emailTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/5).isActive = true // 1/4 of entire height
         
         // emailSeparatorView: need x, y, width, height contraints
         emailSeparatorView.leftAnchor.constraint(equalTo: inputsView.leftAnchor).isActive = true
@@ -245,7 +258,7 @@ class RegisterController: UIViewController {
         passwordTextField.leftAnchor.constraint(equalTo: inputsView.leftAnchor, constant: 12).isActive = true
         passwordTextField.topAnchor.constraint(equalTo: emailTextField.bottomAnchor).isActive = true
         passwordTextField.widthAnchor.constraint(equalTo: inputsView.widthAnchor).isActive = true
-        passwordTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/4).isActive = true // 1/4 of entire height
+        passwordTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/5).isActive = true // 1/4 of entire height
         
         // passwordSeparatorView need x, y, width, height contraints
         passwordSeparatorView.leftAnchor.constraint(equalTo: inputsView.leftAnchor).isActive = true
@@ -257,7 +270,19 @@ class RegisterController: UIViewController {
         chapterTextField.leftAnchor.constraint(equalTo: inputsView.leftAnchor, constant: 12).isActive = true
         chapterTextField.topAnchor.constraint(equalTo: passwordTextField.bottomAnchor).isActive = true
         chapterTextField.widthAnchor.constraint(equalTo: inputsView.widthAnchor).isActive = true
-        chapterTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/4).isActive = true // 1/4 of entire height
+        chapterTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/5).isActive = true // 1/4 of entire height
+        
+        // chapterSeparatorView need x, y, width, height contraints
+        chapterSeparatorView.leftAnchor.constraint(equalTo: inputsView.leftAnchor).isActive = true
+        chapterSeparatorView.topAnchor.constraint(equalTo: chapterTextField.bottomAnchor).isActive = true
+        chapterSeparatorView.widthAnchor.constraint(equalTo: inputsView.widthAnchor).isActive = true
+        chapterSeparatorView.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        
+        // memberTypeTextField need x, y, width, height constraints
+        memberTypeTextField.leftAnchor.constraint(equalTo: inputsView.leftAnchor, constant: 12).isActive = true
+        memberTypeTextField.topAnchor.constraint(equalTo:chapterTextField.bottomAnchor).isActive = true
+        memberTypeTextField.widthAnchor.constraint(equalTo: inputsView.widthAnchor).isActive = true
+        memberTypeTextField.heightAnchor.constraint(equalTo: inputsView.heightAnchor, multiplier: 1/5).isActive = true // 1/4 of entire height
         
     }
     

--- a/src_code/BoundlessBrilliance/View/RegisterView.swift
+++ b/src_code/BoundlessBrilliance/View/RegisterView.swift
@@ -78,11 +78,23 @@ class RegisterView: UIView {
         return view
     }()
     
-    
+    // subview - passwordSeparatorView
+    let chapterSeparatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(r: 220, g: 220, b: 220)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 }
 
 extension UITextField {
-    func loadSpinnerOptions(spinnerOptions: [String]) {
+    func loadChapterOptions(spinnerOptions: [String]) {
+        self.inputView = SpinnerView(spinnerOptions: spinnerOptions, spinnerTextField: self)
+    }
+}
+
+extension UITextField {
+    func loadMemberTypeOptions(spinnerOptions: [String]) {
         self.inputView = SpinnerView(spinnerOptions: spinnerOptions, spinnerTextField: self)
     }
 }


### PR DESCRIPTION
- created memberType Spinner 
- push memberType into Firebase with other user info when registering a new account
- deleted password field in user table so that we aren't storing sensitive information 
- created toast message so that users are forced to choose a chapter and member type when registering (otherwise, it will create an error because paths through Firebase cannot contain blank strings)
- when registering a new account, user ID and name now also gets pushed into the Chapter table
- changed L.A. to Los Angeles because path names cannot contain "."
- moved Firebase entry stuff from outside the "Error in creating account" to inside the else, because we should not be able to store stuff in the database if there is an error with the data they entered